### PR TITLE
Ds 1147/no write func

### DIFF
--- a/creevey/pipelines/core.py
+++ b/creevey/pipelines/core.py
@@ -3,6 +3,7 @@ import logging
 from pathlib import Path
 import time
 from typing import Any, Callable, DefaultDict, Iterable, Optional, Tuple, Union
+import warnings
 
 from joblib import delayed, Parallel
 from numpy import iterable
@@ -21,7 +22,7 @@ class Pipeline:
     Attributes
     ----------
     load_func
-        Callable that takes a string or `Path` object as single
+        Callable that takes a string or `Path` object as a single
         positional argument, reads from the corresponding location, and
         returns some representation of its contents.
     ops
@@ -42,21 +43,13 @@ class Pipeline:
     def __init__(
         self,
         load_func: Callable[[PathOrStr], Any],
-        ops: Optional[Union[Callable[[Any], Any], Iterable[Callable[[Any], Any]]]],
-        write_func: Callable[[Any, PathOrStr], None],
+        ops: Optional[
+            Union[Callable[[Any], Any], Iterable[Callable[[Any], Any]]]
+        ] = None,
+        write_func: Optional[Callable[[Any, PathOrStr], None]] = None,
     ) -> None:
-        """
-        Compose the provided functions, and store them as attributes.
-
-        Store `load_func`, `ops`, and `write_func` as attributes with
-        the corresponding names. Create an additional attribute
-        `pipeline_func` that composes those functions for when `run`
-        is called.
-
-        See the `Pipeline` docstring for information about the form that
-        `load_func`, `ops`, and `write_func` are expected to take.
-        """
         self.load_func = load_func
+
         if callable(ops):
             self.ops = [ops]
         elif iterable(ops):
@@ -67,110 +60,37 @@ class Pipeline:
             raise TypeError(
                 'ops must be callable, an iterable of ' 'callables, or `None`'
             )
+
         self.write_func = write_func
-
-    def pipeline_func(
-        self,
-        inpath: PathOrStr,
-        outpath_func: PathOrStr,
-        skip_existing: bool,
-        log_dict: DefaultDict[str, dict],
-        exceptions_to_catch: Optional[Union[Tuple, Tuple[Exception]]] = None,
-    ) -> None:
-        """
-        Process one file
-
-        Use `self.load_func` to load the file at `inpath` into memory,
-        pipe the result through the functions in `self.ops`, and use
-        `self.write_func` to write it to `outpath_func(inpath)`.
-
-        If `skip_existing` is `True`, check up front whether
-        `outpath_func(inpath)` exists. If it does, skip the file.
-
-        Catch `exceptions_to_catch` if they arise during file processing.
-
-        Parameters
-        ----------
-        inpath
-        outpath_func
-        skip_existing
-        log_dict
-        exceptions_to_catch
-
-        Side effects
-        ------------
-        Record results in a dict within `log_dict[inpath]`:
-            - `outpath_func(inpath)` as "outpath"
-            - 0/1 indicating whether existing file was skipped as
-            "skipped_existing"
-            - 0/1 indicating whether exception of a type specified in
-            `exceptions_to_catch` was handled during processing as
-            "exception_handled"
-            - Timestamp indicating when processing finished as
-            "time_finished"
-        """
-        outpath = outpath_func(inpath)
-        skipped_existing = False
-        exception_handled = False
-
-        if skip_existing and Path(outpath).is_file():
-            skipped_existing = True
-            logging.debug(
-                f'Skipping {inpath} because there is already a file at corresponding '
-                f'output path {outpath}'
-            )
-        else:
-            if exceptions_to_catch is None:
-                self._run_pipeline_func(inpath, outpath, log_dict=log_dict)
-            else:
-                try:
-                    self._run_pipeline_func(inpath, outpath, log_dict=log_dict)
-                except exceptions_to_catch as e:
-                    exception_handled = True
-                    logging.error(e, inpath)
-
-        inpath_logs = log_dict[inpath]
-        inpath_logs['outpath'] = outpath
-        inpath_logs['skipped_existing'] = int(skipped_existing)
-        inpath_logs['exception_handled'] = int(exception_handled)
-        inpath_logs['time_finished'] = time.time()
-
-    def _run_pipeline_func(self, inpath, outpath, **kwargs):
-        # `kwargs` included to handle unused `log_dict` so that
-        # `pipeline_func` does not have to change in
-        # `CustomReportingPipeline`
-        stage = self.load_func(inpath)
-        for op in self.ops:
-            stage = op(stage)
-        self.write_func(stage, outpath)
 
     def run(
         self,
         inpaths: Iterable[PathOrStr],
-        path_func: Callable[[PathOrStr], PathOrStr],
         n_jobs: int,
-        skip_existing: bool = True,
+        path_func: Optional[Callable[[PathOrStr], PathOrStr]] = None,
+        skip_existing: Optional[bool] = None,
         exceptions_to_catch: Optional[Union[Exception, Tuple[Exception]]] = None,
     ) -> pd.DataFrame:
         """
         Run the pipeline.
 
         Across `n_jobs` threads, for each path in `inpaths`, if
-        `skip_existing` is `True` and `path_func` of that path exists,
-        do not do anything. Otherwise, use `load_func` to get the
-        resource from that path, pipe its output through `ops`, and
-        write out the result with `write_func`.
+        `skip_existing` is `True`, `path_func` is not `None`, and
+        `path_func` of that path exists, do not do anything. Otherwise,
+        use `load_func` to get the resource from that path and pipe its
+        output through `ops`; and if `write_func` is not `None`, write
+        the result to `path_func` of that path.
 
         Parameters
         ----------
         inpaths
             Iterable of string or Path objects pointing to resources to
             be processed and written out.
+        n_jobs
+            Number of threads to use.
         path_func
             Function that takes each input path and returns the desired
             corresponding output path.
-        n_jobs
-            Number of threads to use.
         skip_existing
             Boolean indicating whether to skip items that would result
             in overwriting an existing file or to overwrite any such
@@ -180,22 +100,32 @@ class Pipeline:
             these types will be logged with logging level ERROR and the
             relevant file will be skipped.
 
-        Side effects
-        ------------
-        Logs a warning when `skip_existing` is `True`.
+        Raises
+        ------
+        ValueError
+            If `path_func` is `None` but `self.write_func` is not.
+
+        Warns
+        -----
+        UserWarning
+            When `skip_existing` is `True`.
 
         Returns
         -------
-        Pandas DataFrame "run report" with each input path as its
-        index and columns indicating the corresponding output path (
-        "outpath"), whether processing was skipped because a file
-        already existed at the output path ("skipped_existing"),
-        whether processing failed due to an exception in
-        `exceptions_to_catch` ("exception_handled"), and a timestamp
-        indicating when processing complete ("time_finished").
+        Pandas DataFrame "run report" with the values from `inpaths` in
+        its index and a "time_finished" column containing timestamps
+        indicating when processing was completed for each file.
+        If `self.write_func` is not `None`, also includes columns
+        "outpath"; "skipped_existing" indicating whether processing was
+        skipped because a file already existed at the output path; and
+        "exception_handled" indicating whether processing failed due to
+        an exception of a type included in `exceptions_to_catch`.
         """
+        if skip_existing is None:
+            skip_existing = True if self.write_func else False
+        self._check_run_params(path_func=path_func, skip_existing=skip_existing)
         if skip_existing:
-            logging.warning(
+            warnings.warn(
                 'Skipping files where a file exists at the output '
                 'location. Pass `skip_existing=False` to overwrite '
                 'existing files instead.'
@@ -205,7 +135,11 @@ class Pipeline:
 
         Parallel(n_jobs=n_jobs, prefer='threads')(
             delayed(self.pipeline_func)(
-                path, path_func, skip_existing, log_dict, exceptions_to_catch
+                inpath=path,
+                log_dict=log_dict,
+                path_func=path_func,
+                skip_existing=skip_existing,
+                exceptions_to_catch=exceptions_to_catch,
             )
             for path in tqdm(inpaths)
         )
@@ -213,6 +147,114 @@ class Pipeline:
         run_report = pd.DataFrame.from_dict(log_dict, orient='index')
 
         return run_report
+
+    def _check_run_params(self, path_func, skip_existing):
+        if skip_existing and path_func is None:
+            raise ValueError('`skip_existing` must be `False` if `path_func` is `None`')
+        if path_func is None and self.write_func is not None:
+            raise ValueError(
+                '`path_func` can be `None` only if `self.write_func` is `None`.'
+            )
+        return skip_existing
+
+    def pipeline_func(
+        self,
+        inpath: PathOrStr,
+        log_dict: DefaultDict[str, dict],
+        path_func: Optional[Callable[[PathOrStr], PathOrStr]] = None,
+        skip_existing: Optional[bool] = None,
+        exceptions_to_catch: Optional[Union[Tuple, Tuple[Exception]]] = None,
+    ) -> None:
+        """
+        Process one file
+
+        Use `self.load_func` to load the file at `inpath` into memory,
+        and pipe the result through the functions in `self.ops`. If
+        `self.write_func` is not `None`, write the result to
+        `outpath_func(inpath)`.
+
+        If `skip_existing` is `True`, check up front whether
+        `outpath_func(inpath)` exists. If it does, skip the file.
+
+        Catch `exceptions_to_catch` if they arise during file processing.
+
+        Parameters
+        ----------
+        inpath
+            Input path
+        path_func
+            See `self.run` docstring.
+        skip_existing
+            See `self.run` docstring.
+        log_dict
+            Dictionary used to store information for `run_report`.
+        exceptions_to_catch
+            See `self.run` docstring.
+
+        Raises
+        ------
+        ValueError
+            If `skip_existing` is `True` and `path_func` is `None`.
+
+        Notes
+        -----
+        Records results in a dict within `log_dict[inpath]`:
+
+        - `path_func(inpath)` as "outpath", if `path_func` is not `None`
+        - bool indicating whether existing file was skipped as
+        "skipped_existing"
+        - bool indicating whether exception of a type specified in
+        `exceptions_to_catch` was handled during processing as
+        "exception_handled"
+        - Timestamp indicating when processing finished as
+        "time_finished"
+        """
+        self._check_run_params(path_func=path_func, skip_existing=skip_existing)
+
+        skipped_existing = False
+        exception_handled = False
+
+        if skip_existing and Path(path_func(inpath)).is_file():
+            skipped_existing = True
+            logging.debug(
+                f'Skipping {inpath} because there is already a file at '
+                f'corresponding output path {path_func(inpath)}'
+            )
+        else:
+            if exceptions_to_catch:
+                try:
+                    self._run_pipeline_func(
+                        inpath=inpath, path_func=path_func, log_dict=log_dict
+                    )
+                except exceptions_to_catch as e:
+                    exception_handled = True
+                    logging.error(e, inpath)
+            if not exceptions_to_catch:
+                self._run_pipeline_func(
+                    inpath=inpath, path_func=path_func, log_dict=log_dict
+                )
+
+        inpath_logs = log_dict[inpath]
+        if path_func is not None:
+            inpath_logs['outpath'] = path_func(inpath)
+        inpath_logs['skipped_existing'] = int(skipped_existing)
+        inpath_logs['exception_handled'] = int(exception_handled)
+        inpath_logs['time_finished'] = time.time()
+
+    def _run_pipeline_func(
+        self,
+        inpath: PathOrStr,
+        path_func: Optional[Callable[[PathOrStr], PathOrStr]],
+        **kwargs,
+    ):
+        # `kwargs` included to handle unused `log_dict` so that
+        # `pipeline_func` does not have to change in
+        # `CustomReportingPipeline`
+        stage = self.load_func(inpath)
+        for op in self.ops:
+            stage = op(stage)
+        if self.write_func:
+            self.write_func(stage, path_func(inpath))
 
 
 class CustomReportingPipeline(Pipeline):
@@ -234,8 +276,14 @@ class CustomReportingPipeline(Pipeline):
     returns. See Creevey's README for further explanation.
     """
 
-    def _run_pipeline_func(self, inpath, outpath, log_dict):
+    def _run_pipeline_func(
+        self,
+        inpath: PathOrStr,
+        path_func: Optional[Callable[[PathOrStr], PathOrStr]],
+        log_dict: DefaultDict[str, dict],
+    ):
         stage = self.load_func(inpath, log_dict=log_dict)
         for op in self.ops:
             stage = op(stage, inpath=inpath, log_dict=log_dict)
-        self.write_func(stage, outpath, inpath=inpath, log_dict=log_dict)
+        if self.write_func:
+            self.write_func(stage, path_func(inpath), inpath=inpath, log_dict=log_dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,15 @@ from creevey.path_funcs import join_outdir_filename_extension
 TEST_DIR = Path(__file__).parent
 SAMPLE_DATA_DIR = Path(TEST_DIR) / 'sample_data'
 TEMP_DATA_DIR = SAMPLE_DATA_DIR / 'tmp'
-IMAGE_FILENAMES = ['2RsJ8EQ', '2TqoToT', '2VocS58', '2scKPIp', '2TsO6Pc', '2SCv0q7']
-IMAGE_URLS = [f'https://bit.ly/{filename}' for filename in IMAGE_FILENAMES]
+IMAGE_DOWNLOAD_FILENAMES = [
+    '2RsJ8EQ',
+    '2TqoToT',
+    '2VocS58',
+    '2scKPIp',
+    '2TsO6Pc',
+    '2SCv0q7',
+]
+IMAGE_URLS = [f'https://bit.ly/{filename}' for filename in IMAGE_DOWNLOAD_FILENAMES]
 
 from tests.fixtures import *
 

--- a/tests/test_pipelines/test_pipelines_core.py
+++ b/tests/test_pipelines/test_pipelines_core.py
@@ -72,10 +72,21 @@ def test_custom_reporting_pipeline(report_mean_brightness_pipeline):
 
 
 def test_no_write_func():
-    load_images_pipeline = Pipeline(
-        load_func=load_image_from_disk, ops=None, write_func=None
-    )
-    load_images_pipeline.run(
+    Pipeline(
+        load_func=load_image_from_disk,
+        ops=[lambda image: image[:-1, :]],
+        write_func=None,
+    ).run(
         inpaths=[path for path in SAMPLE_DATA_DIR.iterdir() if path.suffix == '.png'],
         n_jobs=1,
     )
+
+
+def test_reporting_no_write_func():
+    run_report = CustomReportingPipeline(
+        load_func=load_image_from_disk, ops=[report_mean_brightness], write_func=None
+    ).run(
+        inpaths=[path for path in SAMPLE_DATA_DIR.iterdir() if path.suffix == '.png'],
+        n_jobs=1,
+    )
+    assert "mean_brightness" in run_report.columns

--- a/tests/test_pipelines/test_pipelines_core.py
+++ b/tests/test_pipelines/test_pipelines_core.py
@@ -4,16 +4,17 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from creevey import CustomReportingPipeline
-from creevey.load_funcs.image import load_image_from_url
+from creevey import CustomReportingPipeline, Pipeline
+from creevey.load_funcs.image import load_image_from_disk, load_image_from_url
 from creevey.ops import get_report_output_decorator
 from creevey.ops.image import calculate_mean_brightness
 from creevey.write_funcs.image import write_image
 from tests.conftest import (
     delete_file_if_exists,
-    IMAGE_FILENAMES,
+    IMAGE_DOWNLOAD_FILENAMES,
     IMAGE_URLS,
     keep_filename_save_png_in_tempdir,
+    SAMPLE_DATA_DIR,
     TEMP_DATA_DIR,
 )
 
@@ -44,7 +45,7 @@ def test_custom_reporting_pipeline(report_mean_brightness_pipeline):
     inpaths = IMAGE_URLS
     outpaths = [
         TEMP_DATA_DIR / Path(filename).with_suffix('.png')
-        for filename in IMAGE_FILENAMES
+        for filename in IMAGE_DOWNLOAD_FILENAMES
     ]
     exception_handled = skipped_existing = [0] * len(inpaths)
     expected_run_report = pd.DataFrame(
@@ -68,3 +69,13 @@ def test_custom_reporting_pipeline(report_mean_brightness_pipeline):
         expected_run_report.sort_index(axis='index').sort_index(axis='columns'),
     )
     assert np.issubdtype(actual_run_report.loc[:, 'mean_brightness'], np.number)
+
+
+def test_no_write_func():
+    load_images_pipeline = Pipeline(
+        load_func=load_image_from_disk, ops=None, write_func=None
+    )
+    load_images_pipeline.run(
+        inpaths=[path for path in SAMPLE_DATA_DIR.iterdir() if path.suffix == '.png'],
+        n_jobs=1,
+    )

--- a/tests/test_pipelines/test_pipelines_image.py
+++ b/tests/test_pipelines/test_pipelines_image.py
@@ -1,5 +1,4 @@
 from functools import partial
-import logging
 from pathlib import Path
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
We might want to use Creevey for file-processing operations that do not involve writing to disk. For instance, we might want to check which of our image files are corrupted. Currently the framework expects a `write_func`, so we have to hack around its assumptions for such use cases. This PR adds support for `write_func=None`.

Contributors from outside ShopRunner should feel free to submit a PR without having completed all of the items below. See [CONTRIBUTING.md](https://github.com/ShopRunner/creevey/blob/master/CONTRIBUTING.md) for additional information. 

**General Pull Request Checklist**

 - [x] Pull request has been made against the `wip` branch (or from `wip` into `master`).
 - [x] Pull request includes a description of the change and the reason behind it.
 - [ ] Pull request [uses keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to close relevant [issues](https://github.com/ShopRunner/creevey/issues).
 - [ ] Pull request includes unit tests for any bug fixes and new functionality.
 - [ ] `README.md` and other docs have been updated as needed.
 - [ ] `./.ci/test.sh` passes locally.
 
The maintainer will complete the following steps for external contributions.

**Additional Items for ShopRunner Contributors**

 - [ ] `CHANGELOG.md` has been updated.
 - [ ] `_version.py` has been updated.
